### PR TITLE
Parse markdown links and newlines in app descriptions

### DIFF
--- a/src/components/app/AppHeader.tsx
+++ b/src/components/app/AppHeader.tsx
@@ -1,6 +1,7 @@
 import { App } from '@/types/components/app';
 import { AppInstallButton } from './AppInstallButton';
 import { AppIcon } from './AppIcon';
+import { TextMarkdown } from './TextMarkdown';
 
 interface AppHeaderProps {
   app: App;
@@ -56,7 +57,10 @@ export function AppHeader({ app, isConfigured, isInstalled, onInstallationChange
         </div>
         <div className="mt-8">
           <h2 className="text-lg font-semibold mb-2">About</h2>
-          <p className="text-gray-600 dark:text-gray-100">{app.description}</p>
+          <TextMarkdown
+            text={app.description}
+            className="text-gray-600 dark:text-gray-100"
+          />
         </div>
       </div>
     </>

--- a/src/components/app/TextMarkdown.tsx
+++ b/src/components/app/TextMarkdown.tsx
@@ -1,0 +1,103 @@
+import { openUrl } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
+
+interface TextMarkdownProps {
+  text: string;
+  className?: string;
+}
+
+function isAppProtocolUrl(url: string): boolean {
+  return /^(?!http|https|ftp)\w+:\/\//.test(url);
+}
+
+async function openUrlWithFallback(url: string) {
+  if (isAppProtocolUrl(url)) {
+    try {
+      await invoke('open_system_url', { url });
+    } catch (error) {
+      console.error(`Failed to open app URL with system command: ${error}`);
+      
+      try {
+        await openUrl(url);
+      } catch (secondError) {
+        console.error(`Failed to open app URL with openUrl: ${secondError}`);
+        
+        window.open(url, '_blank');
+      }
+    }
+  } else {
+    try {
+      await openUrl(url);
+    } catch (error) {
+      console.error(`Failed to open URL: ${error}`);
+      window.open(url, '_blank');
+    }
+  }
+}
+
+function parseMarkdownLinks(text: string): (string | JSX.Element)[] {
+  if (!text) return [];
+
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+  const parts: (string | JSX.Element)[] = [];
+  let lastIndex = 0;
+  let match;
+  
+  while ((match = linkRegex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.substring(lastIndex, match.index));
+    }
+    
+    const [fullMatch, linkText, linkUrl] = match;
+    parts.push(
+      <button 
+        key={`link-${match.index}`} 
+        onClick={() => openUrlWithFallback(linkUrl)}
+        className="text-blue-600 hover:underline dark:text-blue-400 font-normal p-0 bg-transparent border-none cursor-pointer"
+      >
+        {linkText}
+      </button>
+    );
+    
+    lastIndex = match.index + fullMatch.length;
+  }
+  
+  if (lastIndex < text.length) {
+    parts.push(text.substring(lastIndex));
+  }
+  
+  return parts;
+}
+
+function parseLineBreaks(content: (string | JSX.Element)[]): (string | JSX.Element)[] {
+  if (!content.length) return content;
+  
+  const parts: (string | JSX.Element)[] = [];
+  let keyCounter = 0;
+  
+  content.forEach(item => {
+    if (typeof item === 'string' && item.includes('\n')) {
+      const lines = item.split('\n');
+      
+      lines.forEach((line, index) => {
+        parts.push(line);
+        if (index < lines.length - 1) {
+          parts.push(<br key={`br-${keyCounter++}`} />);
+        }
+      });
+    } else {
+      parts.push(item);
+    }
+  });
+  
+  return parts;
+}
+
+export function TextMarkdown({ text, className = "" }: TextMarkdownProps) {
+  const parsedContent = parseLineBreaks(parseMarkdownLinks(text));
+  
+  return <p className={className}>{parsedContent.length > 0 ? parsedContent : text}</p>;
+}
+
+export type { TextMarkdownProps };

--- a/src/components/app/configuration/TextSetupItem.tsx
+++ b/src/components/app/configuration/TextSetupItem.tsx
@@ -1,84 +1,18 @@
-import { openUrl } from '@tauri-apps/plugin-opener';
-import { invoke } from '@tauri-apps/api/core';
+import { TextMarkdown } from '../TextMarkdown';
 
 interface TextSetupItemProps {
   label: string;
   value: string;
 }
 
-function isAppProtocolUrl(url: string): boolean {
-  return /^(?!http|https|ftp)\w+:\/\//.test(url);
-}
-
-async function openUrlWithFallback(url: string) {
-  if (isAppProtocolUrl(url)) {
-    try {
-      await invoke('open_system_url', { url });
-    } catch (error) {
-      console.error(`Failed to open app URL with system command: ${error}`);
-      
-      try {
-        await openUrl(url);
-      } catch (secondError) {
-        console.error(`Failed to open app URL with openUrl: ${secondError}`);
-        
-        window.open(url, '_blank');
-      }
-    }
-  } else {
-    try {
-      await openUrl(url);
-    } catch (error) {
-      console.error(`Failed to open URL: ${error}`);
-      window.open(url, '_blank');
-    }
-  }
-}
-
-function parseMarkdownLinks(text: string) {
-  if (!text) return [];
-
-  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
-  
-  const parts: (string | JSX.Element)[] = [];
-  let lastIndex = 0;
-  let match;
-  
-  while ((match = linkRegex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push(text.substring(lastIndex, match.index));
-    }
-    
-    const [fullMatch, linkText, linkUrl] = match;
-    parts.push(
-      <button 
-        key={match.index} 
-        onClick={() => openUrlWithFallback(linkUrl)}
-        className="text-blue-600 hover:underline dark:text-blue-400 font-normal p-0 bg-transparent border-none cursor-pointer"
-      >
-        {linkText}
-      </button>
-    );
-    
-    lastIndex = match.index + fullMatch.length;
-  }
-  
-  if (lastIndex < text.length) {
-    parts.push(text.substring(lastIndex));
-  }
-  
-  return parts;
-}
-
 export function TextSetupItem({ label, value }: TextSetupItemProps) {
-  const parsedContent = parseMarkdownLinks(value);
-  
   return (
     <div className="flex flex-col gap-2">
       <p className="text-base font-medium">{label}</p>
-      <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
-        {parsedContent.length > 0 ? parsedContent : value}
-      </p>
+      <TextMarkdown
+        text={value}
+        className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400"
+      />
     </div>
   );
 }


### PR DESCRIPTION
- Extracted the code parsing markdown links in `TextSetupItem` into a `TextMarkdown` component (`src/components/app/TextMarkdown.tsx`)
- `TextMarkdown` also parses line breaks `\n`
- Updated `AppHeader` to use `TextMarkdown` for app descriptions