### PR TITLE
Add support for variables in app schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dist-ssr
 .env
 Developer ID*.cer
 Developer ID*.p12
+.aider*

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -939,6 +939,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,10 +1050,12 @@ name = "fleur"
 version = "0.2.9"
 dependencies = [
  "dirs 5.0.1",
+ "env_logger",
  "fleur",
  "lazy_static",
  "log",
  "once_cell",
+ "regex",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -1588,6 +1603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1695,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1990,6 +2017,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi 0.5.0",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3006,7 +3044,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.44",
  "tracing",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,12 +29,14 @@ simplelog = { version = "0.12", features = ["local-offset"] }
 time = { version = "0.3", features = ["formatting"] }
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 once_cell = "1.19"
+regex = "1.10.2"
 
 [dev-dependencies]
 tempfile = "3.8"
 uuid = { version = "1.4", features = ["v4"] }
 serial_test = "2.0"
 fleur = { path = ".", features = ["test-utils"] }
+env_logger = "0.10"
 
 [features]
 test-utils = []

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -70,7 +70,7 @@ fn fetch_app_registry() -> Result<Value, String> {
 
     // Fetch the registry from GitHub
     let registry_url =
-        "https://raw.githubusercontent.com/pranav7/app-registry/p7/11.03.25/stripe-mcp/apps.json";
+        "https://raw.githubusercontent.com/fleuristes/app-registry/refs/heads/main/apps.json";
     info!("Fetching app registry from {}", registry_url);
     let response = get(registry_url).map_err(|e| {
         error!("Failed to fetch app registry: {}", e);


### PR DESCRIPTION
Adds support variables in the config, so that they can be passed to the command in the following format:

```json
  {
    "name": "Stripe",

    "config": {
      "mcpKey": "stripe",
      "runtime": "npx",
      "args": [
        "-y",
        "@stripe/mcp",
        "--tools=all",
        "--api-key=${STRIPE_API_KEY}"
      ]
    },
    "setup": [
      {
        "label": "Get an API Key",
        "value": "You can find your Stripe API key in the Stripe Dashboard under Developers > API keys.",
        "type": "text"
      },
      {
        "label": "Stripe API Key",
        "type": "input",
        "placeholder": "Enter your Stripe API key",
        "value": "Enter your Stripe API key",
        "key": "STRIPE_API_KEY"
      }
    ]
```